### PR TITLE
Add test harness for Eth Common Tests and Bump Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.4
+* Pass common tests for block state and transactions.
 # 0.1.3
 * Add basic support for chains, such as Ropsten versus Homestead.
 * Upgrade EVM to and move `Block.Header` to the EVM project.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-Copyright © 2017 Geoffrey Hayes, Ayrat Badykov, Mason Forest
+Copyright © 2017 Geoffrey Hayes, Ayrat Badykov, Mason Fischer
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by adding `blockchain` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:blockchain, "~> 0.1.3"}]
+  [{:blockchain, "~> 0.1.4"}]
 end
 ```
 
@@ -37,7 +37,8 @@ be found at [https://hexdocs.pm/blockchain](https://hexdocs.pm/blockchain).
 
 Geoffrey Hayes (@hayesgm)
 Ayrat Badykov (@ayrat555)
+Mason Fischer (@masonforest)
 
 ## License
 
-Blockchain is released under the MIT License. See the LICENSE file for further details.
+Exthereum's Blockchain is released under the MIT License. See the LICENSE file for further details.

--- a/lib/bit_helper.ex
+++ b/lib/bit_helper.ex
@@ -125,4 +125,66 @@ defmodule BitHelper do
     end
   end
 
+  @doc """
+  Similar to `:binary.encode_unsigned/1`, except we encode `0` as
+  `<<>>`, the empty string. This is because the specification says that
+  we cannot have any leading zeros, and so having <<0>> by itself is
+  leading with a zero and prohibited.
+
+  ## Examples
+
+      iex> BitHelper.encode_unsigned(0)
+      <<>>
+
+      iex> BitHelper.encode_unsigned(5)
+      <<5>>
+
+      iex> BitHelper.encode_unsigned(5_000_000)
+      <<76, 75, 64>>
+  """
+  @spec encode_unsigned(number()) :: binary()
+  def encode_unsigned(0), do: <<>>
+  def encode_unsigned(n), do: :binary.encode_unsigned(n)
+
+  @doc """
+  Similar to `:binary.decode_unsigned/1`, except we decode `<<>>` back to `0`,
+  which is a common practice in Ethereum, since we cannot have **any** leading
+  zeros.
+
+  ## Examples
+
+      iex> BitHelper.decode_unsigned(<<>>)
+      0
+
+      iex> BitHelper.decode_unsigned(<<5>>)
+      5
+
+      iex> BitHelper.decode_unsigned(<<76, 75, 64>>)
+      5_000_000
+  """
+  @spec decode_unsigned(binary()) :: number()
+  def decode_unsigned(<<>>), do: 0
+  def decode_unsigned(bin), do: :binary.decode_unsigned(bin)
+
+  @doc """
+  Simple wrapper for decoding hex data.
+
+  ## Examples
+
+      iex> BitHelper.from_hex("aabbcc")
+      <<0xaa, 0xbb, 0xcc>>
+  """
+  @spec from_hex(String.t) :: binary()
+  def from_hex(hex_data), do: Base.decode16!(hex_data, case: :lower)
+
+  @doc """
+  Simple wrapper to generate hex.
+
+  ## Examples
+
+      iex> BitHelper.to_hex(<<0xaa, 0xbb, 0xcc>>)
+      "aabbcc"
+  """
+  @spec to_hex(binary()) :: String.t
+  def to_hex(bin), do: Base.encode16(bin, case: :lower)
 end

--- a/lib/blockchain/block.ex
+++ b/lib/blockchain/block.ex
@@ -42,7 +42,7 @@ defmodule Blockchain.Block do
     ...> })
     [
       [<<1::256>>, <<2::256>>, <<3::160>>, <<4::256>>, <<5::256>>, <<6::256>>, <<>>, 5, 1, 5, 3, 6, "Hi mom", <<7::256>>, <<8::64>>],
-      [[5, 6, 7, <<1::160>>, 8, "hi", 27, 9, 10]],
+      [[<<5>>, <<6>>, <<7>>, <<1::160>>, <<8>>, "hi", <<27>>, <<9>>, <<10>>]],
       [[<<11::256>>, <<12::256>>, <<13::160>>, <<14::256>>, <<15::256>>, <<16::256>>, <<>>, 5, 1, 5, 3, 6, "Hi mom", <<17::256>>, <<18::64>>]]
     ]
 
@@ -622,7 +622,7 @@ defmodule Blockchain.Block do
       iex> chain = Blockchain.Test.ropsten_chain()
       iex> beneficiary = <<0x05::160>>
       iex> private_key = <<1::256>>
-      iex> sender = <<125, 110, 153, 187, 138, 191, 140, 192, 19, 187, 14, 145, 45, 11, 23, 101, 150, 254, 123, 136>> # based on simple private key
+      iex> sender = <<126, 95, 69, 82, 9, 26, 105, 18, 93, 93, 252, 183, 184, 194, 101, 144, 41, 57, 91, 223>> # based on simple private key
       iex> machine_code = EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 0, :push1, 32, :return])
       iex> trx = %Blockchain.Transaction{nonce: 5, gas_price: 3, gas_limit: 100_000, to: <<>>, value: 5, init: machine_code}
       ...>       |> Blockchain.Transaction.Signature.sign_transaction(private_key)
@@ -639,7 +639,7 @@ defmodule Blockchain.Block do
       iex> chain = Blockchain.Test.ropsten_chain()
       iex> beneficiary = <<0x05::160>>
       iex> private_key = <<1::256>>
-      iex> sender = <<125, 110, 153, 187, 138, 191, 140, 192, 19, 187, 14, 145, 45, 11, 23, 101, 150, 254, 123, 136>> # based on simple private key
+      iex> sender = <<126, 95, 69, 82, 9, 26, 105, 18, 93, 93, 252, 183, 184, 194, 101, 144, 41, 57, 91, 223>> # based on simple private key
       iex> machine_code = EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 0, :push1, 32, :return])
       iex> trx = %Blockchain.Transaction{nonce: 5, gas_price: 3, gas_limit: 100_000, to: <<>>, value: 5, init: machine_code}
       ...>       |> Blockchain.Transaction.Signature.sign_transaction(private_key)
@@ -745,7 +745,7 @@ defmodule Blockchain.Block do
       iex> db = MerklePatriciaTree.Test.random_ets_db()
       iex> beneficiary = <<0x05::160>>
       iex> private_key = <<1::256>>
-      iex> sender = <<125, 110, 153, 187, 138, 191, 140, 192, 19, 187, 14, 145, 45, 11, 23, 101, 150, 254, 123, 136>> # based on simple private key
+      iex> sender = <<126, 95, 69, 82, 9, 26, 105, 18, 93, 93, 252, 183, 184, 194, 101, 144, 41, 57, 91, 223>> # based on simple private key
       iex> contract_address = Blockchain.Contract.new_contract_address(sender, 6)
       iex> machine_code = EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 0, :push1, 32, :return])
       iex> trx = %Blockchain.Transaction{nonce: 5, gas_price: 3, gas_limit: 100_000, to: <<>>, value: 5, init: machine_code}

--- a/lib/eth_common_test/harness.ex
+++ b/lib/eth_common_test/harness.ex
@@ -3,24 +3,31 @@ defmodule EthCommonTest.Harness do
   Harness for running tests off of the Ethereum Common Test suite.
   """
 
-  defmacro __using__(opts) do
+  defmacro __using__(_opts) do
     quote do
       import EthCommonTest.Helpers
       import EthCommonTest.Harness, only: [eth_test: 4]
     end
   end
 
-  defmacro eth_test(test_set, test_subset, tests, fun) do
-    for {test_name, test} <- EthCommonTest.Helpers.read_test_file(test_set, test_subset),
-      ( tests == :all or Enum.member?(tests, String.to_atom(test_name)) ) do
-        json = Poison.encode!(test)
+  defmacro eth_test(test_set, test_subset_or_subsets, tests, fun) do
+    test_subsets = case test_subset_or_subsets do
+      test_subsets when is_list(test_subsets) -> test_subsets
+      test_subset -> [test_subset]
+    end
 
-        quote do
-          test("#{unquote(test_set)} - #{unquote(test_subset)} - #{unquote(test_name)}") do
-            test = unquote(json) |> Poison.decode!
-            unquote(fun).(test, unquote(test_name))
+    for test_subset <- test_subsets do
+      for {test_name, test} <- EthCommonTest.Helpers.read_test_file(test_set, test_subset),
+        ( tests == :all or Enum.member?(tests, String.to_atom(test_name)) ) do
+          json = Poison.encode!(test)
+
+          quote do
+            test("#{unquote(test_set)} - #{unquote(test_subset)} - #{unquote(test_name)}", test_params) do
+              test = unquote(json) |> Poison.decode!
+              unquote(fun).(test, unquote(test_subset), unquote(test_name), test_params)
+            end
           end
-        end
+      end
     end
   end
 

--- a/lib/eth_common_test/harness.ex
+++ b/lib/eth_common_test/harness.ex
@@ -1,0 +1,27 @@
+defmodule EthCommonTest.Harness do
+  @moduledoc """
+  Harness for running tests off of the Ethereum Common Test suite.
+  """
+
+  defmacro __using__(opts) do
+    quote do
+      import EthCommonTest.Helpers
+      import EthCommonTest.Harness, only: [eth_test: 4]
+    end
+  end
+
+  defmacro eth_test(test_set, test_subset, tests, fun) do
+    for {test_name, test} <- EthCommonTest.Helpers.read_test_file(test_set, test_subset),
+      ( tests == :all or Enum.member?(tests, String.to_atom(test_name)) ) do
+        json = Poison.encode!(test)
+
+        quote do
+          test("#{unquote(test_set)} - #{unquote(test_subset)} - #{unquote(test_name)}") do
+            test = unquote(json) |> Poison.decode!
+            unquote(fun).(test, unquote(test_name))
+          end
+        end
+    end
+  end
+
+end

--- a/lib/eth_common_test/helpers.ex
+++ b/lib/eth_common_test/helpers.ex
@@ -6,6 +6,12 @@ defmodule EthCommonTest.Helpers do
 
   require Integer
 
+  @spec load_integer(String.t) :: integer() | nil
+  def load_integer(""), do: 0
+  def load_integer("x" <> data), do: maybe_hex(data, :integer)
+  def load_integer("0x" <> data), do: maybe_hex(data, :integer)
+  def load_integer(data), do: maybe_dec(data)
+
   @spec maybe_hex(String.t | nil) :: binary() | nil
   def maybe_address(hex_data), do: maybe_hex(hex_data)
 
@@ -15,9 +21,11 @@ defmodule EthCommonTest.Helpers do
   def maybe_hex(hex_data, :raw), do: load_raw_hex(hex_data)
   def maybe_hex(hex_data, :integer), do: load_hex(hex_data)
 
+  @spec maybe_dec(String.t | nil) :: integer() | nil
   def maybe_dec(nil), do: nil
   def maybe_dec(els), do: load_decimal(els)
 
+  @spec load_decimal(String.t) :: integer()
   def load_decimal(dec_data) do
     {res, ""} = Integer.parse(dec_data)
 
@@ -36,7 +44,13 @@ defmodule EthCommonTest.Helpers do
 
   @spec read_test_file(atom(), atom()) :: any()
   def read_test_file(test_set, test_subset) do
-    {:ok, body} = File.read(test_file_name(test_set, test_subset))
+    # This is pretty terrible, but the JSON is just messed up in a number
+    # of these tests (it contains duplicate keys with very strange values)
+    body =
+      File.read!(test_file_name(test_set, test_subset))
+      |> String.split("\n")
+      |> Enum.filter(fn x -> not (x |> String.contains?("secretkey ")) end)
+      |> Enum.join("\n")
 
     Poison.decode!(body)
   end
@@ -46,9 +60,9 @@ defmodule EthCommonTest.Helpers do
     "test/support/ethereum_common_tests/#{test_set}/#{to_string(test_subset)}.json"
   end
 
-  @spec load_src(String.t, String.t, String.t) :: any()
-  def load_src(filler_type, filler, sub_set) do
-    read_test_file("src/#{filler_type}", filler)[sub_set]
+  @spec load_src(String.t, String.t) :: any()
+  def load_src(filler_type, filler) do
+    read_test_file("src/#{filler_type}", filler)
   end
 
 end

--- a/lib/eth_common_test/helpers.ex
+++ b/lib/eth_common_test/helpers.ex
@@ -1,0 +1,54 @@
+defmodule EthCommonTest.Helpers do
+  @moduledoc """
+  Helper functions that will be generally available to test cases
+  when they use `EthCommonTest`.
+  """
+
+  require Integer
+
+  @spec maybe_hex(String.t | nil) :: binary() | nil
+  def maybe_address(hex_data), do: maybe_hex(hex_data)
+
+  @spec maybe_hex(String.t | nil) :: binary() | nil
+  def maybe_hex(hex_data, type \\ :raw)
+  def maybe_hex(nil, _), do: nil
+  def maybe_hex(hex_data, :raw), do: load_raw_hex(hex_data)
+  def maybe_hex(hex_data, :integer), do: load_hex(hex_data)
+
+  def maybe_dec(nil), do: nil
+  def maybe_dec(els), do: load_decimal(els)
+
+  def load_decimal(dec_data) do
+    {res, ""} = Integer.parse(dec_data)
+
+    res
+  end
+
+  @spec load_raw_hex(String.t) :: binary()
+  def load_raw_hex("0x" <> hex_data), do: load_raw_hex(hex_data)
+  def load_raw_hex(hex_data) when Integer.is_odd(byte_size(hex_data)), do: load_raw_hex("0" <> hex_data)
+  def load_raw_hex(hex_data) do
+    Base.decode16!(hex_data, case: :mixed)
+  end
+
+  @spec load_hex(String.t) :: integer()
+  def load_hex(hex_data), do: hex_data |> load_raw_hex |> :binary.decode_unsigned
+
+  @spec read_test_file(atom(), atom()) :: any()
+  def read_test_file(test_set, test_subset) do
+    {:ok, body} = File.read(test_file_name(test_set, test_subset))
+
+    Poison.decode!(body)
+  end
+
+  @spec test_file_name(atom(), atom()) :: String.t
+  def test_file_name(test_set, test_subset) do
+    "test/support/ethereum_common_tests/#{test_set}/#{to_string(test_subset)}.json"
+  end
+
+  @spec load_src(String.t, String.t, String.t) :: any()
+  def load_src(filler_type, filler, sub_set) do
+    read_test_file("src/#{filler_type}", filler)[sub_set]
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Blockchain.Mixfile do
 
   def project do
     [app: :blockchain,
-     version: "0.1.3",
+     version: "0.1.4",
       elixir: "~> 1.4",
       description: "Ethereum's Blockchain Manager",
       package: [

--- a/test/blockchain/block_test.exs
+++ b/test/blockchain/block_test.exs
@@ -7,7 +7,7 @@ defmodule Blockchain.BlockTest do
   alias Blockchain.Block
   alias Blockchain.Transaction
 
-  eth_test "GenesisTests", :basic_genesis_tests, [:test2, :test3], fn test, _test_name ->
+  eth_test "GenesisTests", :basic_genesis_tests, [:test2, :test3], fn test, _test_subset, _test_name, _ ->
     db = MerklePatriciaTree.Test.random_ets_db()
 
     chain = %Blockchain.Chain{

--- a/test/blockchain/transaction_test.exs
+++ b/test/blockchain/transaction_test.exs
@@ -1,17 +1,83 @@
 defmodule Blockchain.TransactionTest do
   use ExUnit.Case, async: true
-  doctest Blockchain.Transaction
-  alias Blockchain.Transaction
   use EthCommonTest.Harness
+  doctest Blockchain.Transaction
 
-  eth_test "TransactionTests", :ttTransactionTest, [:AddressLessThan20], fn test, test_name ->
-    transaction = load_src("TransactionTestsFiller", "ttTransactionTestFiller", test_name)["transaction"] |> IO.inspect |> load_trx |> IO.inspect
+  require Logger
 
-    assert transaction |> Transaction.serialize == test["rlp"] |> load_hex |> :binary.encode_unsigned |> ExRLP.decode
+  alias Blockchain.Transaction
+  alias Blockchain.Transaction.Signature
+
+  # Load filler data
+  setup_all do
+    frontier_filler = load_src("TransactionTestsFiller", "ttTransactionTestFiller")
+    homestead_filler = load_src("TransactionTestsFiller/Homestead", "ttTransactionTestFiller")
+    eip155_filler = load_src("TransactionTestsFiller/EIP155", "ttTransactionTestEip155VitaliksTestsFiller")
+
+    {:ok, %{
+      frontier_filler: frontier_filler,
+      homestead_filler: homestead_filler,
+      eip155_filler: eip155_filler}}
+  end
+
+  eth_test "TransactionTests", :ttTransactionTest, :all, fn test, test_subset, test_name, %{frontier_filler: filler} ->
+    trx_data = test["transaction"]
+    src_data = filler[test_name]
+    transaction = (trx_data || src_data["transaction"]) |> load_trx
+
+    if src_data["expect"] == "invalid" do
+      # TODO: Include checks of "invalid" tests
+      Logger.debug("Skipping `invalid` transaction test: TransactionTests - #{test_subset} - #{test_name}")
+
+      nil
+    else
+      assert transaction |> Transaction.serialize == test["rlp"] |> load_hex |> :binary.encode_unsigned |> ExRLP.decode
+
+      if test["hash"], do: assert transaction |> Transaction.serialize |> ExRLP.encode |> BitHelper.kec == test["hash"] |> maybe_hex
+      if test["sender"], do: assert Signature.sender(transaction) == {:ok, test["sender"] |> maybe_hex}
+    end
+  end
+
+  # Test Homestead
+  eth_test "TransactionTests/Homestead", :ttTransactionTest, :all, fn test, test_subset, test_name, %{homestead_filler: filler} ->
+    trx_data = test["transaction"]
+    src_data = filler[test_name]
+    transaction = (trx_data || src_data["transaction"]) |> load_trx
+
+    if src_data["expect"] == "invalid" do
+      # TODO: Include checks of "invalid" tests
+      Logger.debug("Skipping invalid transaction test: TransactionTests/Homestead - #{test_subset} - #{test_name}")
+
+      nil
+    else
+      assert transaction |> Transaction.serialize == test["rlp"] |> load_hex |> :binary.encode_unsigned |> ExRLP.decode
+
+      if test["hash"], do: assert transaction |> Transaction.serialize |> ExRLP.encode |> BitHelper.kec == test["hash"] |> maybe_hex
+      if test["sender"], do: assert Signature.sender(transaction) == {:ok, test["sender"] |> maybe_hex}
+    end
+  end
+
+  # Test EIP155
+  eth_test "TransactionTests/EIP155", :ttTransactionTestEip155VitaliksTests, :all, fn test, test_subset, test_name, %{eip155_filler: filler} ->
+    trx_data = test["transaction"]
+    src_data = filler[test_name]
+    transaction = (trx_data || src_data["transaction"]) |> load_trx
+    chain_id = 1
+
+    if src_data["expect"] == "invalid" do
+      # TODO: Include checks of "invalid" tests
+      Logger.debug("Skipping invalid transaction test: TransactionTests/EIP555 - #{test_subset} - #{test_name}")
+
+      nil
+    else
+      assert transaction |> Transaction.serialize == test["rlp"] |> load_hex |> :binary.encode_unsigned |> ExRLP.decode
+
+      if test["hash"], do: assert transaction |> Transaction.serialize(chain_id) |> ExRLP.encode |> BitHelper.kec == test["hash"] |> maybe_hex
+      if test["sender"], do: assert Signature.sender(transaction, chain_id) == {:ok, test["sender"] |> maybe_hex}
+    end
   end
 
   describe "when handling transactions" do
-
     test "serialize and deserialize" do
       trx = %Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1::160>>, value: 8, v: 27, r: 9, s: 10, data: "hi"}
 
@@ -21,7 +87,7 @@ defmodule Blockchain.TransactionTest do
     test "for a transaction with a stop" do
       beneficiary = <<0x05::160>>
       private_key = <<1::256>>
-      sender = <<125, 110, 153, 187, 138, 191, 140, 192, 19, 187, 14, 145, 45, 11, 23, 101, 150, 254, 123, 136>> # based on simple private key
+      sender = <<126, 95, 69, 82, 9, 26, 105, 18, 93, 93, 252, 183, 184, 194, 101, 144, 41, 57, 91, 223>> # based on simple private key
       contract_address = Blockchain.Contract.new_contract_address(sender, 6)
       machine_code = EVM.MachineCode.compile([:stop])
       trx = %Blockchain.Transaction{nonce: 5, gas_price: 3, gas_limit: 100_000, to: <<>>, value: 5, init: machine_code}
@@ -40,18 +106,21 @@ defmodule Blockchain.TransactionTest do
     end
   end
 
-  defp load_trx(data) do
+  defp load_trx(trx_data) do
+    to = trx_data["to"] |> maybe_address
+    data = trx_data["data"] |> maybe_hex
+
     %Blockchain.Transaction{
-      nonce: data["nonce"] |> maybe_hex,
-      gas_price: data["gasPrice"] |> maybe_dec,
-      gas_limit: data["gasLimit"] |> maybe_dec,
-      to: data["data"] |> maybe_address,
-      value: data["value"] |> maybe_dec,
-      v: data["v"] |> maybe_dec,
-      r: data["r"] |> maybe_hex,
-      s: data["s"] |> maybe_hex,
-      init: <<>>,
-      data: data["data"] |> maybe_hex,
+      nonce: trx_data["nonce"] |> load_integer,
+      gas_price: trx_data["gasPrice"] |> load_integer,
+      gas_limit: trx_data["gasLimit"] |> load_integer,
+      to: to,
+      value: trx_data["value"] |> load_integer,
+      v: trx_data["v"] |> load_integer,
+      r: trx_data["r"] |> load_integer,
+      s: trx_data["s"] |> load_integer,
+      init: (if to == <<>>, do: data, else: <<>>),
+      data: (if to == <<>>, do: <<>>, else: data)
     }
   end
 end

--- a/test/blockchain/transaction_test.exs
+++ b/test/blockchain/transaction_test.exs
@@ -2,6 +2,13 @@ defmodule Blockchain.TransactionTest do
   use ExUnit.Case, async: true
   doctest Blockchain.Transaction
   alias Blockchain.Transaction
+  use EthCommonTest.Harness
+
+  eth_test "TransactionTests", :ttTransactionTest, [:AddressLessThan20], fn test, test_name ->
+    transaction = load_src("TransactionTestsFiller", "ttTransactionTestFiller", test_name)["transaction"] |> IO.inspect |> load_trx |> IO.inspect
+
+    assert transaction |> Transaction.serialize == test["rlp"] |> load_hex |> :binary.encode_unsigned |> ExRLP.decode
+  end
 
   describe "when handling transactions" do
 
@@ -31,5 +38,20 @@ defmodule Blockchain.TransactionTest do
           %Blockchain.Account{balance: 240983, nonce: 6}, %Blockchain.Account{balance: 159012}, %Blockchain.Account{balance: 5}
         ]
     end
+  end
+
+  defp load_trx(data) do
+    %Blockchain.Transaction{
+      nonce: data["nonce"] |> maybe_hex,
+      gas_price: data["gasPrice"] |> maybe_dec,
+      gas_limit: data["gasLimit"] |> maybe_dec,
+      to: data["data"] |> maybe_address,
+      value: data["value"] |> maybe_dec,
+      v: data["v"] |> maybe_dec,
+      r: data["r"] |> maybe_hex,
+      s: data["s"] |> maybe_hex,
+      init: <<>>,
+      data: data["data"] |> maybe_hex,
+    }
   end
 end


### PR DESCRIPTION
This patch starts to add a test harness for Ethereum Common Tests, with the intent of this lib being pulled into a separate repo entirely, so it can be re-used on a variety of projects. Right now, we're looking at building a simple syntax and set of functions that will be useful for block and transaction tests.