### PR TITLE
Add 12th block to Ropsten test

### DIFF
--- a/test/ropsten_test.exs
+++ b/test/ropsten_test.exs
@@ -8,7 +8,7 @@ defmodule RopstenTest do
 
   use ExUnit.Case, async: true
 
-  @n 11
+  @n 12
 
   setup_all do
     blocks = File.read!("test/support/ropsten_blocks.dat")


### PR DESCRIPTION
This patch adds the 12th block to our Ropsten test code. This shows where we are currently failing to properly process a block.