### PR TITLE
Integrate with EVM debugger [waiting on EVM push]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.5
+* Integrate with EVM debugger
 # 0.1.4
 * Pass common tests for block state and transactions.
 # 0.1.3

--- a/README.md
+++ b/README.md
@@ -25,6 +25,39 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/blockchain](https://hexdocs.pm/blockchain).
 
+## Debugging
+
+To debug a given run of the blockchain, you can set breakpoints on contract addresses by setting the `BREAKPOINT` environment variable and specifying a contract address to break on. E.g.
+
+```bash
+BREAKPOINT=bc1ffc1620da1468624a596cb841d35e6b2f1fb6 iex -S mix
+
+...
+
+00:04:18.739 [warn]  Debugger has been enabled. Set breakpoint #1 on contract address 0xbc1ffc1620da1468624a596cb841d35e6b2f1fb6.
+
+...
+
+-- Breakpoint #1 triggered with conditions contract address 0xbc1ffc1620da1468624a596cb841d35e6b2f1fb6 (start) --
+
+gas: 277888 | pc: 0 | memory: 0 | words: 0 | # stack: 0
+
+----> [ 0] push2
+      [ 1] 0
+      [ 2] 4
+      [ 3] dup1
+      [ 4] push2
+      [ 5] 0
+      [ 6] 14
+      [ 7] push1
+      [ 8] 0
+      [ 9] codecopy
+
+Enter a debug command or type `h` for help.
+
+>>
+```
+
 ## Contributing
 
 1. [Fork it!](https://github.com/exthereum/blockchain/fork)

--- a/lib/blockchain/application.ex
+++ b/lib/blockchain/application.ex
@@ -4,9 +4,22 @@ defmodule Blockchain.Application do
   @moduledoc false
 
   use Application
+  require Logger
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
+
+    if breakpoint_address_hex = System.get_env("BREAKPOINT") do
+      case Base.decode16(breakpoint_address_hex, case: :mixed) do
+        {:ok, breakpoint_address} ->
+          EVM.Debugger.enable()
+          id = EVM.Debugger.break_on(address: breakpoint_address)
+
+          Logger.warn("Debugger has been enabled. Set breakpoint ##{id} on contract address 0x#{breakpoint_address_hex}.")
+        :error ->
+          Logger.error("Invalid breakpoint address: #{breakpoint_address_hex}")
+      end
+    end
 
     # Define workers and child supervisors to be supervised
     children = [


### PR DESCRIPTION
This patch (which won't pass until we push the next version of the EVM), integrates the Blockchain client with the EVM debugger. This gives us an easy way to turn on the debugger when a given contracts code is invoked.