### PR TITLE
Minor Verification API Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.1.5
 * Integrate with EVM debugger
+* Update `verify_and_add_block` command's interface
 # 0.1.4
 * Pass common tests for block state and transactions.
 # 0.1.3

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by adding `blockchain` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:blockchain, "~> 0.1.4"}]
+  [{:blockchain, "~> 0.1.5"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Blockchain.Mixfile do
       {:merkle_patricia_tree, "~> 0.2.5"},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:ex_rlp, "~> 0.2.1"},
-      {:evm, "~> 0.1.10"},
+      {:evm, "~> 0.1.11"},
       {:poison, "~> 3.1.0"},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Blockchain.Mixfile do
 
   def project do
     [app: :blockchain,
-     version: "0.1.4",
+     version: "0.1.5",
       elixir: "~> 1.4",
       description: "Ethereum's Blockchain Manager",
       package: [

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "eleveldb": {:hex, :eleveldb, "2.2.20", "1fff63a5055bbf4bf821f797ef76065882b193f5e8095f95fcd9287187773b58", [:rebar3], [], "hexpm"},
-  "evm": {:hex, :evm, "0.1.10", "3bb9355a563005af9233a5af3d5d6b411070ecb3b52c744f0242697179bb9f9d", [:mix], [{:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:merkle_patricia_tree, "~> 0.2.5", [hex: :merkle_patricia_tree, repo: "hexpm", optional: false]}], "hexpm"},
+  "evm": {:hex, :evm, "0.1.11", "40ffd67eb493dbc53ec1650632e96d2a28d9d81309df7d7f9955519c2bcb83da", [:mix], [{:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:merkle_patricia_tree, "~> 0.2.5", [hex: :merkle_patricia_tree, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_rlp": {:hex, :ex_rlp, "0.2.1", "bd320900d6316cdfe01d365d4bda22eb2f39b359798daeeffd3bd1ca7ba958ec", [:mix], [], "hexpm"},
   "exleveldb": {:hex, :exleveldb, "0.11.1", "37c0414208a50d2419d8246305e6c4a33ed339c25c0bdfa27774795e1e089f7b", [:mix], [{:eleveldb, "~> 2.2.19", [hex: :eleveldb, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This patches changes the signature to verify transactions and add to a block chain. Generally, we allow a slightly more accepting interface, since this not just verify, but it's "verify and add." This is because we might want to lax verification for test cases, or catch issues (like missing parent blocks) without raising an exception.