### PR TITLE
Remove instructions specific to the libsecp256k1 package.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,6 @@ jobs:
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get
-      # TODO: The following step shouldn't be necessary.
-      - run: cd deps/libsecp256k1 && rebar compile
 
       #TODO: uncomment after fixing code style
       # - run: mix credo

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Exthereum's blocks are specified in a variety of sections throughout [the yellow
 
 ```bash
 export "CFLAGS=-I/usr/local/include -L/usr/local/lib"
-cd deps/libsecp256k1 && rebar compile
 mix compile
 ```
 

--- a/mix.lock
+++ b/mix.lock
@@ -10,7 +10,7 @@
   "exleveldb": {:hex, :exleveldb, "0.11.1", "37c0414208a50d2419d8246305e6c4a33ed339c25c0bdfa27774795e1e089f7b", [:mix], [{:eleveldb, "~> 2.2.19", [hex: :eleveldb, repo: "hexpm", optional: false]}], "hexpm"},
   "hex_prefix": {:hex, :hex_prefix, "0.1.0", "e96b5cbb6ad8493196ce193726240023f5ce0ae0753118a19a5b43e2db0267ca", [:mix], [], "hexpm"},
   "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"},
-  "libsecp256k1": {:git, "https://github.com/omisego/libsecp256k1.git", "edf8bfdd246dfb8799828933be7c32e0ec77d07e", []},
+  "libsecp256k1": {:hex, :libsecp256k1, "0.1.4", "42b7f76d8e32f85f578ccda0abfdb1afa0c5c231d1fd8aeab9cda352731a2d83", [:rebar3], [], "hexpm"},
   "merkle_patricia_tree": {:hex, :merkle_patricia_tree, "0.2.6", "4adcc768318582b4ee1cc7ec10b8851fa5708804ead5b7ca9153cec07d57bbdc", [:mix], [{:ex_rlp, "~> 0.2.0", [hex: :ex_rlp, repo: "hexpm", optional: false]}, {:exleveldb, "~> 0.11.1", [hex: :exleveldb, repo: "hexpm", optional: false]}, {:hex_prefix, "~> 0.1.0", [hex: :hex_prefix, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
The package is now pulled through the package manager and compiled by rebar3 automatically via mix.